### PR TITLE
User state to sessionStorage closes #51

### DIFF
--- a/frontend/src/Components/HeaderLoggedIn.js
+++ b/frontend/src/Components/HeaderLoggedIn.js
@@ -12,6 +12,8 @@ function HeaderLogged(){
 
   const handleLogOut = () => {
     dispatch(logoutUser())
+    sessionStorage.removeItem('token')
+    sessionStorage.removeItem('user')
     notification.success({
       message:'Logged out!'
     })

--- a/frontend/src/Components/LoginForm.js
+++ b/frontend/src/Components/LoginForm.js
@@ -20,6 +20,10 @@ function LoginForm(){
 
         try {
             const response = await axios.post('http://localhost:8082/api/auth/login', userLoginInfo)
+
+            sessionStorage.setItem('token', response.data.token)
+            sessionStorage.setItem('user', JSON.stringify(response.data.user))
+
             dispatch(loginUser(response.data));
             history.push("/Birthdays");
             // console.log(response.data.user.firstName)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -9,8 +9,8 @@ const initialBirthdays = {
 */
 
 const initialAuth = {
-  token: null,
-  user: null
+  token: sessionStorage.getItem('token') || null,
+  user: JSON.parse(sessionStorage.getItem('user')) || null
 }
 
 const [combinedReducer, initialState] = combineReducers({


### PR DESCRIPTION
That way we have the state even when a user refreshes the page. But when he/she closes the browser, then the state is deleted too. Not the most secure solution - but it might be the easiest one.

I'll create a new issue for the token's expiration duration. TODO: ideally, once the user has logged out (or closed the browser), the token should become invalid.