### PR TITLE
BE: Added "This rout does not exist" closes #78

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -24,6 +24,10 @@ app.get('/', (req, res) => {
   res.send('Hello World')
 })
 
+app.get('*', (req, res) => {
+  res.send('This route does not exist')
+})
+
 mongoose
   .connect(process.env.MONGODB_URI, {
     useNewUrlParser: true,


### PR DESCRIPTION
This text is shown when someone tries to access BE endpoint, which does not exist.